### PR TITLE
docs(chat-write): planning artifacts for chat-write feature

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,130 @@
+# Pawjai — Glossary
+
+Canonical terms for the codebase. Implementation lives in code; this file only fixes language.
+
+---
+
+## PetRecord
+A single timeline entry for a pet, stored in `pet_records`. Every record has:
+- `recordType`: one of four umbrella categories — `activity`, `symptom`, `vet_visit`, `medication`
+- `typeId`: pointer to a row in `pet_record_types` (the specific subtype, e.g. "diarrhea" under `symptom`)
+- `occurredAt`, `note`, `vibe`, optional images, free-form `metadata`
+
+`PetRecord` is the canonical name in code and internal docs. User-facing UI uses friendly words like "บันทึก" / "log" / "activity (gerund)" — those are not the entity name.
+
+## recordType (umbrella)
+The enum value on `PetRecord.recordType`. Always one of: `activity` | `symptom` | `vet_visit` | `medication`. When ambiguity is possible, write "umbrella recordType" or qualify with the value, e.g. "a `recordType=symptom` PetRecord".
+
+## record subtype
+The row in `pet_record_types` referenced by `PetRecord.typeId`. Examples: "walk" (under `activity`), "diarrhea" (under `symptom`), "annual checkup" (under `vet_visit`), "amoxicillin" (under `medication`). Never call a subtype an "activity" — that name is already taken by the umbrella value.
+
+## "activity" (forbidden in internal docs)
+Banned as a standalone noun in code, schema talk, and design docs because it is overloaded: it can mean (a) the umbrella `recordType=activity`, (b) any `PetRecord`, or (c) the Thai UI label บันทึกกิจกรรม. Use `PetRecord` for the entity and the specific `recordType` value when referring to the umbrella.
+
+User-facing copy (Thai or English) may still say "activity" / "กิจกรรม" — that is a translation choice, not a domain term.
+
+## PetWeightRecord
+A weight entry, stored in `pet_weight_records`. Parallel to `PetRecord` but a separate table with its own route (`/api/pets/:id/weight`). Not a subtype of `PetRecord`. When the chat feature writes weight, it writes to this table, not `pet_records`.
+
+## canonical weight unit
+Database stores weight in **kg only** (`pet_weight_records.weightKg`, `numeric(6,3)`). The user has a display preference at `user_config.weightUnit` (`kg | lb`). Conversion happens at the edge:
+- **Input edge** (chat parsing, form submit): convert to kg before the API call.
+- **Display edge** (timeline, chat confirmation card): convert kg → user's preferred unit at render.
+
+When the chat infers weight from natural language ("น้องหนัก 12 โล" / "Mochi is 26 pounds"), the proposal MUST surface both the user's spoken value (with the unit they said) AND the kg-canonical value. This is the user's last chance to correct unit mis-parsing.
+
+## record-write proposal
+The structured object the chat model emits when it intends to create or amend a `PetRecord` or `PetWeightRecord`. Never written to the DB directly. Shown to the user in a confirmation card; only after user-side confirm does the FE call the existing write API (`/api/pets/:id/records`, `/api/pets/:id/weight`). A proposal has at minimum: target pet, write kind (create | amend), recordType + subtype (or weight + unit), occurredAt, free-form fields. The chat may emit a proposal with **unresolved fields** (no pet picked, ambiguous subtype) — the confirmation UI is responsible for resolving them.
+
+**Vendor-neutral wire format.** The proposal shape on the chat stream (`{ type: 'proposal', payload: {...} }`) is defined by us, not by any LLM vendor's function-call shape. The mapping from vendor-specific tool output (Gemini `functionCall`, OpenAI `tool_calls`, Anthropic `tool_use`, etc.) into our proposal shape happens inside a **`llmToolAdapter`** in the BE. The FE never sees vendor-specific fields. Switching providers means writing one new adapter, not changing the FE or the rest of the BE.
+
+## mapping (confirmation-time)
+The user-driven step where a `record-write proposal` with ambiguous or missing fields is resolved before commit. Three mapping axes:
+1. **Pet mapping** — which of the user's pets this is for (mandatory when user has >1 pet).
+2. **Subtype mapping** — which `pet_record_types` row this PetRecord references (e.g. "diarrhea" vs "soft stool" under `symptom`).
+3. **Unit / time mapping** — weight unit (kg ↔ lb), occurredAt (now vs "yesterday morning" → concrete timestamp).
+
+A proposal cannot be committed while any mapping axis is unresolved. The confirmation card renders a control for each unresolved axis. The chat must never silently guess and commit — guesses appear in the card as pre-filled but editable values.
+
+## amendable window
+The set of `PetRecord` / `PetWeightRecord` rows the chat is allowed to amend (edit) via tool call. Defined as: records created **by this same chat conversation** (tracked via a `createdInChatId` or equivalent column / metadata). Anything older — including records created via the timeline UI or via a previous chat session — is read-only from chat. Amending those redirects the user to the timeline.
+
+## confirmation gate
+A hard, always-on requirement: no `record-write proposal` may be committed without an explicit user tap on a confirm control in the FE. There is no "auto-commit after N seconds", no "remember my choice", no "trust the model" flag, no batch confirm. Every create and every amend is a separate confirmation. The BE enforces this by never writing to `pet_records` / `pet_weight_records` from the chat orchestrator — writes only happen when the FE calls the existing record-write APIs (`/api/pets/:id/records`, `/api/pets/:id/weight`) after user confirmation.
+
+## premium gate
+The chat-write feature (proposing and committing records via chat) is restricted to users whose `accessControlService` returns `effectivePlan === 'premium'`. Free users still get the read-only chat experience (the same as today) but cannot trigger record-write proposals. Gate is enforced in two places:
+- **BE chat orchestrator**: when `subscriptionTier !== 'premium'`, the LLM is configured without the record-write tools. Free users physically cannot get a proposal back.
+- **FE chat UI**: any record-write affordance (suggestion chips, slash commands, etc.) renders the existing `<UpgradeDialog>` for free users instead of triggering the tool flow.
+
+A premium user who downgrades mid-conversation loses tool access on the next request — there is no in-flight grandfathering.
+
+## proposal card
+The FE rendering of a `record-write proposal`. Lifecycle:
+1. **First appearance**: card auto-opens as a modal as soon as it arrives in the stream, blocking further chat input until the user decides (confirm / cancel / dismiss).
+2. **Inline after dismissal**: once the modal closes, the card collapses to an inline message in the chat scroll (same vertical position the model would have written into), showing a summary, the resolved values, and a state badge (`confirmed` | `cancelled` | `pending`).
+3. **Re-openable**: tapping the inline card reopens it as a modal. Pending cards reopen as fully editable; confirmed/cancelled cards reopen as read-only with a status line ("Confirmed at 14:32" / "You cancelled this proposal").
+
+A new proposal from the model **supersedes** any prior pending proposal in the same conversation — the previous pending card collapses to `cancelled (superseded)` state.
+
+## chat-driven edit
+The user revises a proposal or amends a recently-committed record by talking to the LLM. Two flavours, both bound by the same "LLM never guesses" rule:
+
+- **Edit-during-proposal**: a pending `proposal card` is on screen. User says "use Mochi instead" or "it was yesterday morning". The LLM emits a revised proposal that **supersedes** the prior one.
+- **Edit-after-commit**: a confirmed record exists *within the* `amendable window`. User says "change that diarrhea time to 7am". The LLM emits an `amend` proposal, which goes through the same `proposal card` confirmation gate.
+
+Records **outside** the amendable window (old, or timeline-created) cannot be edited by chat. The LLM's response in that case is to direct the user to the timeline.
+
+## "LLM never guesses" rule
+If a user instruction is ambiguous, the LLM **must ask a clarifying question** rather than emit a proposal with guessed values. Examples of ambiguity that force a clarification turn (not a proposal):
+- "change the time" with no time given and >1 candidate record in the amendable window
+- "log diarrhea" when user has >1 pet and no pet was named
+- "she gained weight" with no number
+
+A proposal with **pre-filled-but-editable** fields is not a guess — that is the model surfacing its best parse for the user to confirm or correct in the card. The line: if the field has a confidently-parsed value with a recognisable source token in the user's message, it can be pre-filled. If it is invented from thin air, the model must ask instead.
+
+## proposal-card field controls
+The `proposal card` exposes these field controls. Each is pre-filled per the rules below; values shown are always editable until commit.
+
+- **Pet picker** — horizontal avatar row. Hidden if user has 1 pet (auto-resolved). Pre-selected to the pet the model identified; tapping switches local target with no LLM round-trip.
+- **Subtype picker** — dropdown of valid `pet_record_types` for the chosen `recordType`, filtered by species. Pre-filled to the model's resolved row. **Fallback rule:** if the model cannot map the user's words to any row, it does NOT emit a proposal with an empty subtype — it asks a clarifying question instead (e.g. "ผมยังไม่แน่ใจว่าเป็นอาการแบบไหน — ใช่ ท้องเสีย หรือ อาเจียน หรือ...?"). The picker offers `Other` as a free-text safety valve for cases the model resolves but the user wants to override.
+- **Time picker** — relative chooser (Now / 30 min ago / 1 hr ago / This morning / Yesterday / Custom). **Default rule:** pre-fill to `Now` unless the user's message contained an explicit time token (e.g. "เมื่อเช้า", "yesterday at 8pm").
+- **Weight unit toggle** (weight proposals only) — `kg | lb` segmented control. Pre-filled to the unit the user spoke. Toggling **converts** the displayed value (never silently rescales). The card always shows the canonical kg value beneath in muted text.
+- **Note** — free-text, pre-filled with whatever the model captured beyond structured fields.
+
+## amend-target identity
+An amend `record-write proposal` carries the target record's `recordId` directly in its payload. The LLM resolves identity, not the FE. To make this possible, the BE chat context includes an **"Amendable records in this conversation"** section listing `{ recordId, subtype label, occurredAt }` for every chat-created record in the current `conversationId`. This is how the LLM enumerates candidates to apply the "LLM never guesses" rule — when the user says "change the time" and there are 2 candidates, the LLM sees 2 entries and asks which one.
+
+A new column **`created_in_chat_id` (uuid, nullable, indexed)** on both `pet_records` and `pet_weight_records` is the source of truth for "this row was created by chat conversation X". Records created via the timeline have it null. The column powers the context-loader query and the server-side amendable-window check.
+
+## amendable-window enforcement
+Two layers, defense-in-depth:
+1. **FE (primary)** — the LLM only ever sees and proposes amends for records in the amendable window because the BE context only lists those records. The FE never renders an amend card for an out-of-window record.
+2. **BE (secondary)** — the existing `PATCH /records/:id` and `PATCH /pets/:petId/weight/:weightId` endpoints accept an optional `viaChatConversationId` field. When present, the BE verifies `record.createdInChatId === viaChatConversationId` and returns `403 CHAT_AMEND_FORBIDDEN` on mismatch. Timeline PATCH calls omit the field and behave as today.
+
+## deleted-record proposal card
+When a proposal card persisted in `chat_messages` references a `pet_record` that has since been soft-deleted from the timeline, the chat message stays as-is. The FE detects the deleted state at fetch time (record missing or `isDeleted=true`) and renders the inline card with a "This record was deleted from the timeline" status badge. No mirrored deleted-state on the chat message.
+
+## proposal card persistence
+Proposal cards are persisted as rows in the existing `pet_chat_messages` (or equivalent chat messages) table — not as separate entities. The proposal payload, its resolved values, and its current status (`pending` | `confirmed` | `cancelled` | `superseded`) live in the message row's `metadata` JSONB. This means conversation history reload reconstructs the inline card UI exactly as the user left it.
+
+## chat-write failure UX
+Keep it simple. Two failure modes matter:
+1. **Premium expired between proposal-emit and confirm-click** — confirm POST fails with the existing tier error. The card shows an error state with a "Resume subscription to use this" link to the upgrade flow. The proposal stays pending; no retry until resubscribed.
+2. **Any other commit failure** (rate limit, validation, network) — card shows the error message; the user can retry from the same card.
+
+There is no auto-retry, no proposal-staging table, no offline-confirm queue. If it fails, it shows the error and lets the user try again or cancel.
+
+## chat-write discovery (onboarding)
+First-time premium users discover the feature via a one-time popup with example phrasings ("Try: 'Mochi pooped at 8am'"). Dismissal is tracked in the DB using the same pattern as the existing dashboard tutorial flag (look up the dashboard onboarding tracker — this is the source of truth for the column/table to reuse). No persistent UI nudge after the first-run popup; the LLM teaches the affordance by responding to natural language. The popup never shows for free users.
+
+## multi-proposal turn
+A single user message may cause the model to emit multiple `record-write proposal`s in one turn (e.g. "Mochi pooped and peed today" → two proposals). Rules:
+
+- **Hard cap: 3 proposals per turn.** Enforced in the tool-call schema (`maxItems: 3` on any array param). If the user implies more, the LLM is prompted to either pick the top 3 or ask the user to split the request.
+- **Sequential queue, never stacked.** Only one `proposal card` modal is open at a time. The first auto-opens. Confirming, cancelling, or dismissing it auto-opens the next. A small "N more to decide" indicator on the modal tells the user what's coming.
+- **One card per record.** Each proposal is independent — its own card, own confirm/cancel/supersede lifecycle, own inline collapsed entry in the chat scroll. There is no "confirm all" affordance.
+- The model's surrounding text reply (the optional `summary` field on each proposal) makes the group cohesive: "ขอบันทึก 2 อย่างให้นะครับ — อันแรกคือ..." appears as the first card's summary.
+
+## Timeline
+The chronological view of a pet's `PetRecord` + `PetWeightRecord` entries, rendered by `components/petLog/`. Edits and deletions to existing records happen here — the chat feature never deletes, it redirects to the timeline.

--- a/docs/adr/0001-chat-write-confirm-architecture.md
+++ b/docs/adr/0001-chat-write-confirm-architecture.md
@@ -1,0 +1,46 @@
+# 0001 — Chat-driven record writes require FE-side confirmation; BE never auto-commits
+
+**Status:** Accepted
+**Date:** 2026-05-21
+
+## Context
+
+We are adding the ability for users to create and amend `PetRecord` / `PetWeightRecord` entries from the `/chat` page through natural conversation. The backend chat already runs Gemini and streams text to the FE; it has no tool-call wiring today. We are introducing tool calls for the first time as part of this feature.
+
+The team's hard requirement is that **every write must be confirmed by the user in the UI** — no exceptions, no "trust the model" mode. Users with up to ~10 pets need a chance to fix pet-mapping, subtype-mapping, and unit-mapping mistakes before any DB write happens.
+
+Four architectures were considered:
+
+1. **BE auto-commits when the LLM emits a tool call**, then FE shows a "done" toast and an undo.
+2. **BE writes a `pending_proposal` row in a staging table**, FE polls/streams, user confirms, BE moves it to the real table.
+3. **BE intercepts the LLM tool call but does not write**; instead it streams a structured `proposal` event to the FE. FE renders a confirmation card and, on confirm, calls the existing `/api/pets/:id/records` and `/api/pets/:id/weight` write endpoints.
+4. **Hybrid: BE writes immediately but in a `confirmed=false` state**; FE flips the bit on confirm.
+
+## Decision
+
+Adopt **option 3**: BE proposes, FE commits via existing endpoints.
+
+- The chat orchestrator declares LLM tools (`propose_pet_record`, `propose_weight_record`, `amend_pet_record`, `amend_weight_record`) via a **vendor-neutral adapter** (`llmToolAdapter`). Today the adapter targets Gemini; in the future, swapping to another provider means writing a sibling adapter, not changing call sites.
+- The orchestrator never executes the tool. When the model emits a tool call, the adapter normalises it to our internal `proposal` shape and the orchestrator streams `{ type: 'proposal', payload: {...} }` over the existing chat stream.
+- The FE consumes the vendor-neutral proposal shape and renders a confirmation card. On confirm, the FE calls the existing record-write APIs (the same ones the timeline UI uses). On cancel, nothing happens server-side.
+- The premium gate is enforced in the orchestrator: free users get a tool-less LLM configuration. They cannot receive proposals at all.
+
+## Consequences
+
+**Good:**
+- No new staging table; no new "is this row real yet?" state to migrate or clean up.
+- The write path is the **same code** the timeline already uses, including its rate limits, plan checks, and validation. We don't fork the write path.
+- Abandoned proposals leave zero database footprint — the user closes the tab, nothing happened.
+- Each tool category maps 1:1 to an existing REST endpoint, so the FE confirmation handler is a thin switch.
+
+**Bad / trade-offs:**
+- **Two network legs per write**: chat stream returns proposal, then a separate POST to commit. Adds one round-trip's worth of latency between user-confirm and timeline-updated.
+- **The proposal payload is "trusted" by the FE-side commit logic only as a draft.** The FE still must let the user edit every field before commit, and the final POST body is whatever the user confirmed in the UI — never the raw model output. (This is how we keep the model honest.)
+- **No server-side memory of "the model wanted to write X but the user cancelled"**, beyond what we choose to log for analytics. If we ever want to ask "what proposals get cancelled most?" we have to add logging explicitly.
+- **Idempotency is the FE's job.** If the user double-taps confirm, the FE must guard against double-POST. The BE write endpoints already do not enforce idempotency keys today; we will not add them in this feature unless duplication shows up in practice.
+
+## Rejected alternatives
+
+- **Option 1 (BE auto-commit + undo)**: violates the team's hard rule. "Confirm every time" is non-negotiable, and an undo button is not a confirmation.
+- **Option 2 (staging table)**: introduces a new entity, new lifecycle, new garbage collection. Solves a problem we don't have — the FE can hold the proposal in component state until commit.
+- **Option 4 (`confirmed=false` row)**: same downsides as option 2, plus it pollutes timeline queries with "is this real?" filters forever.

--- a/docs/chat-write-admin-analytics.md
+++ b/docs/chat-write-admin-analytics.md
@@ -1,0 +1,148 @@
+# Chat-Write — Admin Analytics & Reporting
+
+Companion to the BE / FE inventories. Defines what admins see and how the data gets there. Pair with `CONTEXT.md`, `docs/adr/0001-chat-write-confirm-architecture.md`, `docs/chat-write-backend-inventory.md`, `docs/chat-write-frontend-inventory.md`.
+
+The pattern below mirrors existing admin analytics:
+- BE service per domain: e.g. `analyticsAiService`, `analyticsEngagementService` (`pawjai-be/src/services/`).
+- Admin routes per namespace: `analytics-ai.ts`, `analytics-engagement.ts` (`pawjai-be/src/routes/admin/`), mounted under `/analytics` prefix.
+- Admin app page per dimension: `app/admin/analytics/ai-usage/`, `chat-health/`, etc.
+- Reuse `PeriodSelector`, `AnalyticsSection`, `MetricsGrid` from `pawjai-admin/components/admin/analytics/`.
+
+---
+
+## Data source rule
+
+Admin analytics queries the **database**, not Mixpanel. Every admin metric must be derivable from DB rows.
+
+Most chat-write metrics derive from data the feature already writes:
+- `pet_records.created_in_chat_id` — chat-created vs timeline-created records.
+- `pet_weight_records.created_in_chat_id` — same for weight.
+- `pet_chat_messages.metadata` (JSONB) — proposal payload + status (`pending` / `confirmed` / `cancelled` / `superseded` / `commit_failed`) + error code on failure.
+
+Two extra crumbs of data needed (both JSONB additions, **no new column or table**):
+
+1. **Commit-failure tracking** — FE writes status `commit_failed` + `errorCode` into the chat message's metadata on commit failure. Otherwise failures leave no DB trace.
+2. **Edited fields tracking** — FE writes `editedFields: string[]` (subset of `pet | subtype | time | unit | note`) into the chat message's metadata on commit. Powers the "which mapping does the LLM fail at most" chart.
+
+---
+
+## What admins need to see
+
+### 1. Adoption funnel (per period)
+1. Premium users who opened `/chat` in the period.
+2. → who received at least one proposal.
+3. → who confirmed at least one proposal.
+4. → still using chat-write 7 days later (retention slice).
+
+### 2. Quality signals
+- **Confirm rate** = `confirmed / emitted`.
+- **Edit rate per field** — % of confirmed proposals where each field was edited. Tells you which mapping the LLM fails at most.
+- **Cancel reasons** — `user_cancelled` vs `superseded` vs `error`.
+- **Avg proposals per confirmed record** — 1.0 means perfect first parse; 2.5 means lots of supersession.
+
+### 3. Volume / breakdown
+- Proposals emitted / confirmed / cancelled per `recordType` (`activity` / `symptom` / `vet_visit` / `medication` / `weight`).
+- Top confirmed subtype rows (e.g. "diarrhea is logged most often").
+
+### 4. Reliability
+- Commit failure rate.
+- Failure code breakdown (`PREMIUM_EXPIRED`, `RATE_LIMIT`, `VALIDATION`, `NETWORK`).
+- Median + p95 time from proposal emitted to commit success.
+
+### 5. Outliers / abuse
+- Top users by chat-write volume.
+- Multi-proposal cap hits — how often does the LLM try to emit >3 in a turn?
+
+---
+
+## Deliberately excluded from v1
+
+- Real-time / streaming metrics — match existing batch + period-based analytics.
+- Per-pet drilldown — volume too low to be meaningful.
+- Cohort analysis (e.g. "users acquired in March who use chat-write") — save for later engagement-service expansion.
+- Reading actual conversation content — privacy-sensitive, separate feature if ever.
+
+---
+
+## BE additions
+
+### New service functions (`src/services/analyticsEngagementService.ts`)
+
+| Function | Returns |
+|---|---|
+| `getChatWriteOverview(period)` | Adoption funnel + per-recordType volume. |
+| `getChatWriteQuality(period)` | Confirm rate, edit-rate-per-field, cancel reasons, avg proposals per confirmed record. |
+| `getChatWriteReliability(period)` | Failure rate, error-code breakdown, p50/p95 proposal-to-commit latency. |
+| `getChatWriteTopUsers(period, limit)` | Top N users by chat-write volume (abuse / outlier surface). |
+
+Use the existing `startDateFromPeriod(period)` helper and the existing `PERIOD_DURATION` / `Period` types.
+
+### New route file (`src/routes/admin/analytics-chat-write.ts`)
+
+Mirrors `analytics-engagement.ts` structure. Exports `analyticsChatWriteRoutes(fastify)`. Four endpoints:
+
+- `GET /admin/analytics/chat-write/overview?period=...`
+- `GET /admin/analytics/chat-write/quality?period=...`
+- `GET /admin/analytics/chat-write/reliability?period=...`
+- `GET /admin/analytics/chat-write/top-users?period=...&limit=...`
+
+### Wire-up (`src/routes/admin/index.ts`)
+Register `analyticsChatWriteRoutes` with prefix `/analytics`, alongside `analyticsEngagementRoutes`.
+
+### Schema delta
+**None** beyond the JSONB additions to `pet_chat_messages.metadata` (no migration required — it's already JSONB).
+
+The `created_in_chat_id` column from `docs/chat-write-backend-inventory.md` is already planned; this report reuses it.
+
+### Permissions
+Same `requireAdminRole` middleware as other analytics routes. No new permission concept.
+
+---
+
+## Admin app additions (`pawjai-admin`)
+
+### New page
+- `app/admin/analytics/chat-write/page.tsx` — chat-write dashboard. Sits next to `chat-health/`.
+
+### New components (`components/admin/analytics/chat-write/`)
+| Component | Purpose |
+|---|---|
+| `ChatWriteFunnel.tsx` | Adoption funnel viz (4 stages). |
+| `ChatWriteFieldEditChart.tsx` | Bar chart of edit rate per field. The most actionable chart in this dashboard. |
+| `ChatWriteReliabilityCard.tsx` | Failure rate + error code donut. |
+| `ChatWriteRecordTypeBreakdown.tsx` | Stacked bars by `recordType`. |
+| `ChatWriteQualityCards.tsx` | Confirm rate, avg proposals per confirmed record, cancel reasons. |
+| `ChatWriteTopUsers.tsx` | Table of top users by volume. |
+
+### Reused (do not fork)
+- `PeriodSelector`, `AnalyticsSection`, `MetricsGrid` from `components/admin/analytics/`.
+
+---
+
+## FE additions to support the report (`pawjai-fe`)
+
+These are small but mandatory writebacks to `pet_chat_messages.metadata`. Adding to the FE inventory by reference:
+
+1. **On commit success** — FE PATCHes the chat message metadata with `status: 'confirmed'`, `editedFields: string[]`, `confirmedAt: timestamp`.
+2. **On commit failure** — FE PATCHes with `status: 'commit_failed'`, `errorCode: string`.
+3. **On cancel** — FE PATCHes with `status: 'cancelled'`, `reason: 'user_cancelled' | 'superseded'`.
+4. **On supersession** — when a new proposal supersedes a prior pending one, the prior gets `status: 'superseded'`.
+
+This requires either:
+- (a) Reusing the existing chat message PATCH endpoint (if one exists) for metadata updates, or
+- (b) Adding `PATCH /pets/:petId/chat/messages/:messageId/metadata` to `pawjai-be/src/routes/pet-chat.ts` for metadata-only updates.
+
+**Recommended: (b)** — keeps the message-content path immutable and adds a clearly-scoped metadata-only endpoint. Lower risk of accidentally letting the FE rewrite message text.
+
+---
+
+## Implementation order
+
+1. Ship the feature (BE + FE inventories) without admin analytics. Metadata writebacks land as part of FE work.
+2. Ship admin analytics one dashboard at a time. Start with the funnel + field-edit chart — those answer the two biggest questions ("are people using it?" and "where does the LLM fail?"). Defer reliability and top-users to the second pass.
+
+---
+
+## Open follow-ups
+- Decide which existing admin-side date/time / chart primitives to use for the funnel (`recharts`? `tremor`? Whatever is already there). Inspect `components/admin/analytics/` before building from scratch.
+- Confirm `requireAdminRole` is the right middleware by reading `src/routes/admin/analytics-engagement.ts`'s preHandler.

--- a/docs/chat-write-backend-inventory.md
+++ b/docs/chat-write-backend-inventory.md
@@ -1,0 +1,135 @@
+# Chat-Write — Backend Changes Inventory
+
+Source of truth for what changes in `pawjai-be` to ship the chat-write feature. Pair with `CONTEXT.md` (glossary) and `docs/adr/0001-chat-write-confirm-architecture.md` (architecture decision). All line numbers below reference state as of 2026-05-21.
+
+---
+
+## 1. New files
+
+| Path | Purpose |
+|---|---|
+| `src/services/chat/llm-tool-adapter.ts` | Vendor-neutral adapter. Maps Gemini `functionCall` output into our `RecordWriteProposal` shape. Single export: `normalizeToolCall(rawCandidate)`. Swapping providers = writing a sibling file, no call-site changes. |
+| `src/services/chat/proposal.types.ts` | Shared TS types: `RecordWriteProposal`, `ProposalKind = 'create' \| 'amend'`, `ProposalStatus`, plus the vendor-neutral tool schema definitions (`PROPOSE_PET_RECORD_TOOL`, `PROPOSE_WEIGHT_RECORD_TOOL`, `AMEND_PET_RECORD_TOOL`, `AMEND_WEIGHT_RECORD_TOOL`). Imported by adapter, orchestrator, and prompt builder. |
+
+---
+
+## 2. Modified files
+
+### `src/services/llm.ts`
+- `generateChatStream` (line 227): change yield type from `string` to `string | { type: 'tool_call'; name: string; args: unknown }`. When a Gemini chunk carries a `functionCall` part, yield the tool-call variant; otherwise yield text as today.
+- `generateChat` (line 145): same return-type extension for the non-streaming path.
+
+### `src/services/chat/orchestrator.service.ts`
+- `ChatStreamEvent` union (line 75): add `| { type: 'proposal'; payload: RecordWriteProposal }`.
+- `sendMessageStream` (line 321): inside the stream loop (current lines 473–484), branch on yielded value. Text → existing `{ type: 'chunk' }`. Tool call → call `normalizeToolCall` (from `llm-tool-adapter.ts`), then yield `{ type: 'proposal', payload }`.
+- Premium gate: at the `modelConfig` selection point near line 408, conditionally attach `tools: RECORD_WRITE_TOOLS` to the LLM call only when `subscriptionTier === 'premium'`. Free users get an identical call without the `tools` field.
+- `sendMessage` (line 87): same tool-call fan-out for the non-streaming path (proposal returned inside `ChatResponse`).
+
+### `src/config/chat-persona.config.ts`
+- Add `generateChatWriteToolSection(locale)` exporting the conditional tool-use prose block appended to the system prompt for premium users.
+
+### `src/services/chat/prompt-builder.service.ts`
+- `buildChatPrompt` (line 84): accept `subscriptionTier`. When premium, append `generateChatWriteToolSection` output to `systemPrompt`.
+- `buildFocusedConversationContext`: extend to render the "Amendable records in this conversation" section. Data comes from a new context-loader query.
+
+### `src/services/chat/context-loader.service.ts` and `context-builder.service.ts`
+- New query: select `pet_records.id`, `pet_record_types.nameEn`, `pet_record_types.nameTh`, `pet_records.occurredAt` joined where `pet_records.created_in_chat_id = :conversationId`. Same for `pet_weight_records`.
+- Stitch into the context block under a clearly-labelled "Amendable records in this conversation" header (around `buildFocusedConversationContext` line 203).
+
+### `src/routes/petRecord.ts`
+- POST handler (line 64): extend `createBodySchema` with optional `createdInChatId: z.string().uuid().optional()`. Pass through to `petRecordService.createRecord`.
+- PATCH handler (line 280): extend `updateBodySchema` with optional `viaChatConversationId: z.string().uuid().optional()`. After fetching the record, if the field is present and `record.createdInChatId !== viaChatConversationId`, return `403 CHAT_AMEND_FORBIDDEN`.
+
+### `src/routes/petWeight.ts`
+- POST handler (line 13): pass `createdInChatId` through to `petWeightService.createWeightRecord`.
+- PATCH handler (line 66): same `viaChatConversationId` enforcement as the record route.
+
+### `src/services/petRecordServices.ts` and `src/services/petWeightService.ts`
+- Accept `createdInChatId` on create paths and write it to the new column.
+
+---
+
+## 3. Schema changes
+
+In `src/db/schema/pets.ts`:
+
+- `pet_records` (table def at line 174): add `createdInChatId: uuid('created_in_chat_id')` — nullable, no FK.
+- `pet_weight_records` (table def at line 200): add the same column.
+- Add a btree index on `created_in_chat_id` for both tables (used by the context-loader query).
+
+No new tables. No new enums. One migration generated via `bun run db:generate`. Use `IF NOT EXISTS` guards.
+
+---
+
+## 4. New API endpoints
+
+**None.** Every chat-write commit reuses an existing endpoint:
+
+- `POST /pets/:petId/records` — chat-create for `PetRecord`
+- `POST /pets/:petId/weight` — chat-create for `PetWeightRecord`
+- `PATCH /records/:id` — chat-amend for `PetRecord`
+- `PATCH /pets/:petId/weight/:weightId` — chat-amend for `PetWeightRecord`
+
+The SSE stream endpoint `POST /pets/:petId/chat` (`pet-chat.ts` line 26) already exists; it only gains a new event variant via the orchestrator change above.
+
+---
+
+## 5. Modified API endpoints
+
+All changes are **additive optional fields** — no breaking changes; timeline UI callers pass nothing and behave identically.
+
+- `POST /pets/:petId/records` — optional `createdInChatId` on body.
+- `POST /pets/:petId/weight` — optional `createdInChatId` on body.
+- `PATCH /records/:id` — optional `viaChatConversationId` on body; BE enforces amendable-window if present.
+- `PATCH /pets/:petId/weight/:weightId` — same as above.
+
+---
+
+## 6. Streaming contract change
+
+Current `ChatStreamEvent` (orchestrator.service.ts line 75) is a three-variant union: `chunk`, `done`, `error`. Add a fourth:
+
+```ts
+{ type: 'proposal'; payload: RecordWriteProposal }
+```
+
+`RecordWriteProposal` (in `proposal.types.ts`) carries at minimum:
+- `kind: 'create' | 'amend'`
+- For records: `petId`, `recordType`, `typeId`, `occurredAt`, `note?`, `vibe?`, `imageUrls?`
+- For weight: `petId`, `weightKg`, `displayUnit ('kg' | 'lb')`, `displayValue` (the user's spoken number), `occurredAt`
+- For amends: `recordId`
+- `conversationId` (FE passes back on commit so amendable-window can be enforced)
+- `summary?` (optional LLM-authored sentence rendered at the top of the card)
+
+The SSE handler in `pet-chat.ts` line 136 writes events via `writeEvent` with no type-specific branching, so that file does not change.
+
+---
+
+## 7. Premium-gate enforcement points
+
+**Primary gate (BE):** `sendMessageStream` (orchestrator.service.ts line 321) and `sendMessage` (line 87). `subscriptionTier` is already resolved (line 336 / line 105). At the `modelConfig` selection point near line 408, pass `tools: RECORD_WRITE_TOOLS` only when premium. Free users get a tool-less LLM and cannot emit `functionCall` responses.
+
+**Secondary gate (FE):** out of scope for this inventory. Renders `<UpgradeDialog>` for free users per `CONTEXT.md`.
+
+The premium gate is **separate from** the existing chat rate limit (`chatRateLimitService.tryClaimMessageSlot`) — both apply, in order.
+
+---
+
+## 8. System prompt sections to add
+
+In `chat-persona.config.ts`, six new sections, applied only when `subscriptionTier === 'premium'`:
+
+1. **Record-write tool definitions** — declares the four tools with parameter schemas (vendor-neutral; adapter maps to Gemini wire format).
+2. **Amendable-window rule** — LLM may only amend records listed in the "Amendable records in this conversation" context block; otherwise direct user to timeline.
+3. **"LLM never guesses" rule** — if a field has no confidently-parsed source token in the user's message, ask a clarifying question; do not invent values.
+4. **Multi-proposal cap** — 3-proposal-per-turn maximum, enforced both via `maxItems: 3` in tool schema and a prose instruction to ask the user to split overflowing requests.
+5. **Weight unit handling** — surface both the user's spoken value (with their unit) and the canonical kg value in weight proposals.
+6. **Proposal supersession** — a new proposal supersedes any prior pending proposal in the same conversation; the LLM should not re-emit a proposal it already sent.
+
+---
+
+## Open follow-ups (not in this inventory)
+
+- FE inventory (separate doc) — proposal card component, SSE event handler change, `UpgradeDialog` integration, first-time popup.
+- Onboarding tracker reuse — confirm the existing dashboard tutorial flag table/column to piggyback on.
+- Analytics — track proposal-emitted, proposal-confirmed, proposal-cancelled, proposal-superseded events through `lib/analytics.ts` (FE side).

--- a/docs/chat-write-frontend-inventory.md
+++ b/docs/chat-write-frontend-inventory.md
@@ -1,0 +1,102 @@
+# Chat-Write — Frontend Changes Inventory
+
+Source of truth for what changes in `pawjai-fe` to ship the chat-write feature. Pair with `CONTEXT.md`, `docs/adr/0001-chat-write-confirm-architecture.md`, and `docs/chat-write-backend-inventory.md`. All line numbers below reference state as of 2026-05-21.
+
+---
+
+## 1. New files
+
+| Path | Purpose |
+|---|---|
+| `components/chat/proposal/ProposalCard.tsx` | The inline + modal proposal renderer. Takes a `RecordWriteProposal` + status; exposes confirm / cancel / edit-field callbacks. Pure view component. |
+| `components/chat/proposal/ProposalCardInline.tsx` | Collapsed-in-chat version of the card. Renders summary + status badge + tap-to-reopen. |
+| `components/chat/proposal/ProposalQueue.tsx` | Sequential-queue controller. Holds the array of pending proposals from one turn and opens them one-at-a-time as modals. |
+| `components/chat/proposal/PetPicker.tsx` | Horizontal avatar row. Hidden when user has 1 pet. |
+| `components/chat/proposal/SubtypePicker.tsx` | Filtered dropdown over `pet_record_types` for the chosen `recordType`. Includes the "Other" free-text safety valve. |
+| `components/chat/proposal/TimePicker.tsx` | Relative chooser (Now / 30m / 1h / Yesterday / Custom). Defaults to "Now" unless message contained a time token. |
+| `components/chat/proposal/WeightUnitToggle.tsx` | kg/lb segmented control built on the existing `lib/utils/weightConversion.ts` util. Always shows canonical kg below the editable value. |
+| `components/chat/ChatWriteOnboardingDialog.tsx` | One-time popup with example phrasings. Gated on the new tutorial flag (see "Tutorial flag" doc). |
+| `lib/api/chatWriteService.ts` | Thin wrapper around existing record + weight POST/PATCH endpoints. Centralises `createdInChatId` / `viaChatConversationId` plumbing so callers don't need to remember to pass them. |
+| `types/chatProposal.ts` | TS types mirroring BE's `RecordWriteProposal`. Hand-mirrored on purpose — keeps the FE/BE boundary explicit. |
+
+---
+
+## 2. Modified files
+
+### `components/chat/ChatInterface.tsx`
+- Wire the proposal queue: when the SSE handler emits `{ type: 'proposal' }`, push onto `<ProposalQueue>`.
+- Mount `<ChatWriteOnboardingDialog>` for premium users who haven't dismissed it.
+
+### `components/chat/hooks/useConversationManager.ts`
+- Extend the message-list type to include proposal messages.
+- On conversation reload, reconstruct queue state from `chat_messages.metadata` JSONB (proposal payload + status).
+
+### `components/chat/ChatMessage.tsx`
+- Branch: if `message.kind === 'proposal'`, render `<ProposalCardInline>`. Otherwise existing text rendering.
+
+### `components/chat/ChatInput.tsx`
+- Disable input while a proposal modal is open. Implements the "must decide before continuing" rule from the glossary.
+
+### `lib/analytics.ts`
+- Add the 8 new tracking methods listed in the Analytics section below.
+
+### `app/chat/page.tsx`
+- No structural change; the dialog mounts via `ChatInterface`. Listed for awareness only.
+
+---
+
+## 3. FE-side correctness rules
+
+- **Idempotency**: confirm button disables on click until POST resolves. Re-enable only on completion (success or error).
+- **Card holds its own state until commit**. Editing fields = local component state. Only at confirm does it call the API.
+- **On commit success**: card → `confirmed` state; invalidate `queryClient.invalidateQueries({ queryKey: ['petRecords', petId] })` and `['petWeight', petId]`; auto-open the next pending proposal in the queue.
+- **Pet picker visibility rule**: hidden iff `pets.length === 1`. Always shown when user has 2+ pets, even if the LLM resolved a pet from context.
+
+---
+
+## 4. SSE event handler extension
+
+Current chat stream consumer parses three event types (`chunk`, `done`, `error`). Add a fourth handler branch in `useConversationManager`:
+
+```ts
+case 'proposal':
+  proposalQueue.push(event.payload);
+  break;
+```
+
+The queue handles ordering and modal auto-open. No timeline / record invalidation here — that happens on commit, not on proposal arrival.
+
+---
+
+## 5. Premium gating in FE
+
+Two gates (per CONTEXT.md):
+- **Suggestion chips / slash commands for record-write affordances** (when added) render the existing `<UpgradeDialog>` for free users.
+- **Receiving a proposal as a free user is unreachable** — the BE doesn't emit them. No FE-side defense needed beyond not building affordances that imply writes work for free users.
+
+---
+
+## 6. Analytics — 8 new events
+
+All events use the existing `pepe*` prefix and route through `track.*` methods in `lib/analytics.ts`.
+
+| Event | Props | Purpose |
+|---|---|---|
+| `pepeWriteProposalEmitted` | `recordType`, `kind` (`create` / `amend`), `petCount` | Top-of-funnel rate. |
+| `pepeWriteProposalOpened` | `recordType`, `kind` | First modal paint. |
+| `pepeWriteProposalEdited` | `recordType`, `field` (`pet` / `subtype` / `time` / `unit` / `note`) | **Most valuable.** Which mapping does the LLM get wrong most? |
+| `pepeWriteProposalConfirmed` | `recordType`, `kind`, `editedFieldCount` | Funnel finish + first-parse quality. |
+| `pepeWriteProposalCancelled` | `recordType`, `reason` (`user_cancelled` / `superseded` / `error`) | Funnel leak. |
+| `pepeWriteCommitFailed` | `recordType`, `errorCode` | Reliability signal. |
+| `pepeWriteOnboardingShown` | (none) | Onboarding popup impressions. |
+| `pepeWriteOnboardingDismissed` | `outcome` (`tried_example` / `closed`) | Did the popup work? |
+
+### Naming + style rules
+- Match the existing `pepe*` convention. Don't fork.
+- Go through `track.*` methods only. Never `trackEvent` directly from components.
+- One event per logical user action. Debounce the cancel handler to prevent double-fire.
+
+### Deliberately excluded
+- Keystrokes in the note field.
+- "User typed a message" (already covered by `pepeMessageSent`).
+- "Modal closed without decision" — same outcome as cancel; distinguishing is hindsight bias.

--- a/docs/chat-write-onboarding-flag.md
+++ b/docs/chat-write-onboarding-flag.md
@@ -1,0 +1,55 @@
+# Chat-Write — Onboarding Tutorial Flag
+
+Companion to the FE / BE inventories. Decides how the first-time chat-write popup is tracked.
+
+---
+
+## Decision
+
+**Add a parallel column `chat_write_tutorial_completed_at timestamp` on `user_profiles`. Do not reuse the existing `tutorial_completed_at`.**
+
+---
+
+## Why not reuse the dashboard flag?
+
+The existing `user_config.tutorial_completed_at` (schema: `src/db/schema/users.ts` line 77) is a single timestamp serving one tutorial — the dashboard tour. The team controls re-display via a `TUTORIAL_RESET_BEFORE` constant on FE.
+
+Reusing it for chat-write would mean:
+- Dismissing the dashboard tour silently dismisses chat-write onboarding too.
+- Bumping `TUTORIAL_RESET_BEFORE` for any one tutorial re-shows them all.
+- The same coupling compounds with every future tutorial.
+
+---
+
+## Alternatives considered
+
+1. **Reuse the existing column** — rejected: coupling above.
+2. **`user_tutorials` table** (`user_id`, `tutorial_key`, `completed_at`) — rejected as over-engineered for ~3 tutorials. Adds a join + a query on every page that gates on a flag.
+3. **Parallel column** — accepted: same pattern as the dashboard one, same `TUTORIAL_RESET_BEFORE` mechanism, same shape of API. One column, one row of code change in the service.
+
+---
+
+## The trigger to refactor
+
+**Two flag columns is fine. Three is the trigger to refactor to a `user_tutorials` table.** Document this rule so the team doesn't slide into 8 columns by accident.
+
+---
+
+## Smallest implementation
+
+### Schema
+- `src/db/schema/users.ts` — add `chatWriteTutorialCompletedAt: timestamp('chat_write_tutorial_completed_at')` on the `userConfig` table, next to the existing `tutorialCompletedAt` (line 77).
+
+### Service
+- `src/services/userConfigService.ts` — add `getChatWriteTutorialCompletedAt(userId)` and `markChatWriteTutorialCompleted(userId)`. Copy-paste-edit of the existing dashboard tutorial methods.
+
+### Routes
+- `src/routes/users-preferences.ts` — add two routes mirroring the existing tutorial ones (lines 117 and 135):
+  - `GET /settings/chat-write-tutorial-status`
+  - `PATCH /settings/chat-write-tutorial-completed`
+
+### FE hook
+- `hooks/useChatWriteTutorial.ts` — returns `{ hasSeen: boolean; markSeen: () => void }`. Same shape as the existing dashboard tutorial hook.
+
+### Gate the dialog
+- `components/chat/ChatWriteOnboardingDialog.tsx` — renders only when premium AND `!hasSeen`. On close (any outcome), call `markSeen()`.


### PR DESCRIPTION
## Summary

Authoritative spec for the chat-write feature. Pairs with:

- pawjai-be#212
- pawjai-fe#259
- pawjai-admin#31

## What this PR contains

- **CONTEXT.md** — glossary (18 terms). PetRecord vs activity disambiguation, amendable window, premium gate, mapping rules, confirmation gate.
- **docs/adr/0001-chat-write-confirm-architecture.md** — the "BE proposes, FE commits via existing endpoints" decision. Vendor-neutral LLM adapter pattern. Alternatives considered and rejected.
- **docs/chat-write-backend-inventory.md** — concrete BE files / schema / endpoints / prompt sections.
- **docs/chat-write-frontend-inventory.md** — FE files / components / SSE handling / analytics events.
- **docs/chat-write-onboarding-flag.md** — single-column flag pattern; rule that 3 flags is the refactor trigger.
- **docs/chat-write-admin-analytics.md** — what admins see, what data drives it, deliberately excluded items.

## Why merge separately

The submodule PRs each reference these docs; without them in version control, reviewers can't click through to the authoritative spec.

## Test plan

- [ ] Reviewers can navigate from the BE/FE/admin PRs to the docs and back

🤖 Generated with [Claude Code](https://claude.com/claude-code)